### PR TITLE
Return numeric descriptor from create

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -276,7 +276,7 @@ declare module 'fuse-bindings' {
 		 * @param mode 
 		 * @param cb 
 		 */
-		create?(path: string, mode: number, cb: (code: number) => void): void;
+		create?(path: string, mode: number, cb: (code: number, fd: number) => void): void;
 
 		/**
 		 * Called when the atime/mtime of a file is being changed.


### PR DESCRIPTION
If you don't create nice unique numeric descriptor in create, then you are in for agony of pain when creating a file system that uses numeric descriptors.
If you rely only on paths', then old example that omitted passing out descriptor will do.

Without explicit descriptor, zero is **silently** passed to FUSE, and FUSE will come to you back with zero. All simplicity of uniqueness goes out the window, and agony starts to burn.