### PR TITLE
modified for a more compliant version of node-fuse-bindings

### DIFF
--- a/fuse-bindings.cc
+++ b/fuse-bindings.cc
@@ -1333,7 +1333,7 @@ NAN_METHOD(Unmount) {
 
 void Init(v8::Local<v8::Object> exports) {
 
-  v8::Local<v8::Context> context = exports->CreationContext();
+  v8::Local<v8::Context> context = exports->GetCreationContext().ToLocalChecked();
 
   exports->Set(context, Nan::New("setCallback").ToLocalChecked(), Nan::New<FunctionTemplate>(SetCallback)->GetFunction(context).ToLocalChecked());
   exports->Set(context, Nan::New("setBuffer").ToLocalChecked(), Nan::New<FunctionTemplate>(SetBuffer)->GetFunction(context).ToLocalChecked());

--- a/package.json
+++ b/package.json
@@ -15,18 +15,18 @@
   },
   "gypfile": true,
   "dependencies": {
-    "nan": "^2.14.0",
-    "node-gyp": "^6.0.1",
-    "node-gyp-build": "^4.2.0",
-    "prebuild-install": "^5.3.3",
+    "nan": "^2.20.0",
+    "node-gyp": "^10.2.0",
+    "node-gyp-build": "^4.8.1",
+    "prebuild-install": "^7.1.2",
     "xtend": "^4.0.2"
   },
   "devDependencies": {
     "concat-stream": "^2.0.0",
-    "prebuild": "^9.1.1",
-    "prebuildify": "^3.0.4",
-    "standard": "^14.3.1",
-    "tape": "^4.11.0"
+    "prebuild": "^13.0.1",
+    "prebuildify": "^6.0.1",
+    "standard": "^17.1.0",
+    "tape": "^5.8.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Since, packages have evolved during these last years, dependencies needed to be updated. There was also an error arising while using node-gyp related to source code that was fixed.

However, npm audit is still indicating that some dependencies have critical issues and the code is still generating many warning (most of them being related to api deprecating) when compiled with node-gyp.